### PR TITLE
Android API Level 34 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a Cordova/Phonegap plugin to interact with the BlueBird ruggedized devic
 =============
 
 This plugin is compatible with plugman.  To install, run the following from your project command line: 
-```$ cordova plugin add https://github.com/BlueFletch/cordova-bluebird-api.git```
+```$ cordova plugin add https://github.com/henrique-gerhardt/cordova-bluebird-api.git --nofetch```
 
 
 ==============

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a Cordova/Phonegap plugin to interact with the BlueBird ruggedized devic
 =============
 
 This plugin is compatible with plugman.  To install, run the following from your project command line: 
-```$ cordova plugin add https://github.com/henrique-gerhardt/cordova-bluebird-api.git --nofetch```
+```$ cordova plugin add https://github.com/BlueFletch/cordova-bluebird-api.git --nofetch```
 
 
 ==============

--- a/lib/android/com/bluefletch/bluebird/BaseIntentHandler.java
+++ b/lib/android/com/bluefletch/bluebird/BaseIntentHandler.java
@@ -91,12 +91,12 @@ public abstract class BaseIntentHandler {
 
             resultCallbackMap.put(OPEN_REQUEST_ID, openResult);
 
-            applicationContext.registerReceiver(dataReceiver, new IntentFilter(getCallbackDataReceivedIntent()));
+            applicationContext.registerReceiver(dataReceiver, new IntentFilter(getCallbackDataReceivedIntent()), Context.RECEIVER_NOT_EXPORTED);
 
             IntentFilter requestFilter = new IntentFilter();
             requestFilter.addAction(getCallbackSuccessIntent());
             requestFilter.addAction(getCallbackFailedIntent());
-            applicationContext.registerReceiver(resultReceiver, requestFilter);
+            applicationContext.registerReceiver(resultReceiver, requestFilter, Context.RECEIVER_NOT_EXPORTED);
 
             Intent openIntent = new Intent(getOpenIntent());
             openIntent.putExtra(EXTRA_SEQUENCE_ID, OPEN_REQUEST_ID);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cordova-bluebird-api",
+  "version": "1.0.0",
+  "description": "Cordova Bluebird Plugin\r ============",
+  "main": "index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/burinmatheus/cordova-bluebird-api.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/burinmatheus/cordova-bluebird-api/issues"
+  },
+  "homepage": "https://github.com/burinmatheus/cordova-bluebird-api#readme"
+}

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/burinmatheus/cordova-bluebird-api.git"
+    "url": "git+https://github.com/BlueFletch/cordova-bluebird-api.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/burinmatheus/cordova-bluebird-api/issues"
+    "url": "https://github.com/BlueFletch/cordova-bluebird-api/issues"
   },
-  "homepage": "https://github.com/burinmatheus/cordova-bluebird-api#readme"
+  "homepage": "https://github.com/BlueFletch/cordova-bluebird-api#readme"
 }


### PR DESCRIPTION
Starting with Android 14, the system requires explicit specification of whether a BroadcastReceiver should be exported or not exported to control visibility to other applications. Without this configuration, the app may crash when registering the BroadcastReceiver.

This pull request updates the BroadcastReceiver registration code in BaseIntentHandler.java to include the necessary visibility parameter for compatibility with Android 14 and 15.